### PR TITLE
Add html5lib dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     scripts=[],
     zip_safe=False,
-    install_requires=['lxml'],
+    install_requires=['lxml', 'html5lib'],
     cmdclass={},
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
The library installs fine from PyPI, but is leads to an "ImportError: No module named html5lib" when the library is imported.
